### PR TITLE
Hyphenate checks-name

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const createCheck = ({ pass, failureStatus, output, startedAt, context }) => {
   const pullRequest = context.payload.pull_request;
 
   let checkOptions = {
-    name: "Jira Ticket Checker",
+    name: "jira-ticket-checker",
     head_sha: pullRequest.head.sha,
     started_at: startedAt
   };


### PR DESCRIPTION
Typically, a probot's name is either one word, one word with alternating
caps, or hyphenated and lowercased. This commit removes the unorthodox
spaces.