### PR TITLE
Set up CircleCI and add trigger event RND-226

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2.1
+
+executors:
+  cd:
+    docker:
+      - image: artnetdev.azurecr.io/automation-dockerimage-cd:1.0.3
+        auth:
+          username: $DOCKER_USER_RO
+          password: $DOCKER_PASSWORD_RO
+
+jobs:
+  deploy:
+    executor: cd
+    steps:
+      - checkout
+      - run:
+          name: Synchronize deployment with Github repository
+          command: |
+            npx sync-glitch-cli
+  
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - deploy:
+          filters:
+            branches:
+              only:
+                - master
+          context: org-global-v2

--- a/index.js
+++ b/index.js
@@ -165,5 +165,15 @@ const check = async context => {
 };
 
 module.exports = app => {
-  app.on(["pull_request.opened", "pull_request.edited", "pull_request.reopened", "pull_request.synchronize", "pull_request.review_requested"], check);
+  app.on(
+    [
+      "pull_request.opened",
+      "pull_request.edited",
+      "pull_request.reopened",
+      "pull_request.synchronize",
+      "pull_request.review_requested",
+      "check_run.rerequested"
+    ],
+    check
+  );
 };


### PR DESCRIPTION
This commit creates a `.circleci/config.yml` file with a `deploy` job
that runs `npx sync-glitch-cli` to synchronize the Glitch deployment
with the `artnetworldwide/automation-jira-ticket-checker` Github
repository.

Also, a `check_run.rerequested` event has been added to `app.on`