### PR TITLE
Use `circleci/node:10.16` docker image instead RND-226 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cd:
     docker:
-      - image: circleci/node:10.16
+      - image: node:10.16.3-buster
 
 jobs:
   deploy:
@@ -24,4 +24,3 @@ workflows:
             branches:
               only:
                 - master
-          context: org-global-v2


### PR DESCRIPTION
This image should have what is needed to run `npx`