### PR TITLE
Exclude Non-Feature Branches in Jira Ticket Check

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,17 @@ const check = async context => {
       context
     });
   }
+  
+  const regexFromString = (str) => {
+    const [, pattern, flag] = /^\/(.*)\/([a-z]*)$/.exec(str)
+    return new RegExp(pattern, flag)
+  }
+
+  const headBranchExcluded = config.exclusionRegEx ? regexFromString(config.exclusionRegEx).test(branch) : false
+
+  if (headBranchExcluded) {
+    return createCheck({ pass: true, startedAt, context });
+  }
 
   const validatedJiraRefs = jiraRefs.map(ref =>
     validateJiraRefs(ref, config.jiraBaseUrl)


### PR DESCRIPTION
`headBranchExcluded` is a boolean value based on the existance of a
regular expression string in the `.Github` `config.yml` file. The
regular expression determines what branches to include in the check.
Anything matching `/(develop$|master$|hotfix/|release/)/i` will be
excluded—so basically only feature branches will be required to
contain a Jira ticket number. `headBranchExcluded` defaults to false.

This PR is connected to this PR in the `.Github` repository:
https://github.com/artnetworldwide/.github/pull/2/files